### PR TITLE
Improve conv2d DSL

### DIFF
--- a/core/src/commonMain/kotlin/sk/ai/net/nn/Conv2d.kt
+++ b/core/src/commonMain/kotlin/sk/ai/net/nn/Conv2d.kt
@@ -13,12 +13,12 @@ class Conv2d(
     val kernelSize: Int,
     val stride: Int = 1,
     val padding: Int = 0,
-    useBias: Boolean = true
+    useBias: Boolean = true,
+    name: String = "Conv2d"
 ) : Module() {
+    override val name: String = name
     val weight: Tensor
     val bias: Tensor?
-    override val name: String
-        get() = "Conv2d"
     override val modules: List<Module>
         get() = emptyList()
 


### PR DESCRIPTION
## Summary
- add a `CONV2D` DSL interface
- implement `Conv2dImpl` builder and change `conv2d` function to use it
- allow naming `Conv2d` modules

## Testing
- `./gradlew build -x test` *(fails: No route to host)*