### PR TITLE
Add Dokka KDoc support

### DIFF
--- a/KDOC_PREPROCESSING.md
+++ b/KDOC_PREPROCESSING.md
@@ -1,0 +1,5 @@
+# KDoc preprocessing
+
+This project follows the same approach as [Kotlin/DataFrame](https://github.com/Kotlin/dataframe/blob/master/KDOC_PREPROCESSING.md) for preprocessing KDoc comments before generating documentation with Dokka.
+
+The Dokka plugin is applied to all modules. Run `./gradlew dokkaHtml` to generate HTML documentation under each module's `build/dokka` directory.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,10 +1,15 @@
+import org.jetbrains.dokka.gradle.DokkaMultiModuleTask
+
 plugins {
     alias(libs.plugins.androidLibrary) apply false
     alias(libs.plugins.kotlinMultiplatform) apply  false
     alias(libs.plugins.jetbrainsKotlinJvm) apply false
     alias(libs.plugins.binaryCompatibility) apply false
+    alias(libs.plugins.dokka) apply false
     alias(libs.plugins.modulegraph.souza) apply true
 }
+
+apply(plugin = "org.jetbrains.dokka")
 
 allprojects {
     group = "sk.ai.net"
@@ -14,4 +19,8 @@ allprojects {
 moduleGraphConfig {
     readmePath.set("./Modules.md")
     heading = "### Module Graph"
+}
+
+tasks.register<org.jetbrains.dokka.gradle.DokkaMultiModuleTask>("dokkaHtmlMultiModule") {
+    outputDirectory.set(buildDir.resolve("dokka"))
 }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
     alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.androidLibrary)
     alias(libs.plugins.binaryCompatibility)
+    alias(libs.plugins.dokka)
     alias(libs.plugins.vanniktech.mavenPublish)
 }
 

--- a/gguf/build.gradle.kts
+++ b/gguf/build.gradle.kts
@@ -4,6 +4,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.androidLibrary)
+    alias(libs.plugins.dokka)
     alias(libs.plugins.vanniktech.mavenPublish)
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,3 +26,4 @@ kotlinSerialization = { id = "org.jetbrains.kotlin.plugin.serialization", versio
 binaryCompatibility = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version.ref = "binaryCompatibility" }
 modulegraph-souza = { id = "dev.iurysouza.modulegraph", version.ref = "moduleGraphSouza" }
 vanniktech-mavenPublish = { id = "com.vanniktech.maven.publish", version = "0.32.0" }
+dokka = { id = "org.jetbrains.dokka", version = "1.9.20" }

--- a/io/build.gradle.kts
+++ b/io/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.androidLibrary)
     alias(libs.plugins.kotlinSerialization)
+    alias(libs.plugins.dokka)
 
     alias(libs.plugins.vanniktech.mavenPublish)
 }


### PR DESCRIPTION
## Summary
- add Dokka plugin to build system
- apply Dokka to modules
- create aggregated Dokka task
- document KDoc pre-processing approach

## Testing
- `./gradlew --version` *(fails: No route to host)*
- `./gradlew test` *(fails: No route to host)*